### PR TITLE
docs: update README and example app to show errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ import { trpc } from "~/utils/trpc";
 import { useTRPCForm } from "trpc-forms";
 
 const App = () => {
-  // 🤯 Pass your mutation to the hook
   const { register, handleSubmit } = useTRPCForm({
+    // 🤯 Pass your mutation to the hook
     mutation: trpc.post.create,
     // 🧩 Use your ordinary trpc mutation options
     mutationOptions: {

--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ import { useTRPCForm } from "trpc-forms";
 
 const App = () => {
   // 🤯 Pass your mutation to the hook
-  const { register, handleSubmit } = useTRPCForm(trpc.post.create, {
+  const { register, handleSubmit } = useTRPCForm({
+    mutation: trpc.post.create,
     // 🧩 Use your ordinary trpc mutation options
-    onMutate() {
-      // ...
-    },
-    onSuccess() {
-      // ...
+    mutationOptions: {
+      onMutate() {
+        // ...
+      },
+      onSuccess() {
+        // ...
+      },
     },
   });
 

--- a/packages/example-app/src/pages/index.tsx
+++ b/packages/example-app/src/pages/index.tsx
@@ -10,8 +10,20 @@ export const PostValidator = z.object({
 });
 
 const Home: NextPage = () => {
-  const { handleSubmit, register, formState, ...rest } = useTRPCForm({
+  const { post } = trpc.useContext();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+    ...rest
+  } = useTRPCForm({
     mutation: trpc.post.add,
+    mutationOptions: {
+      onSuccess: () => {
+        rest.reset();
+        post.list.invalidate();
+      },
+    },
     validator: PostValidator,
   });
   const { data: posts } = trpc.post.list.useQuery();
@@ -22,12 +34,15 @@ const Home: NextPage = () => {
       <form onSubmit={handleSubmit}>
         <label htmlFor="author">Author</label>
         <input {...register("author")} />
+        {errors?.author && <p>{errors.author.message}</p>}
 
         <label htmlFor="title">Title</label>
         <input {...register("title")} />
+        {errors?.title && <p>{errors.title.message}</p>}
 
         <label htmlFor="body">Body</label>
         <input {...register("body")} />
+        {errors?.body && <p>{errors.body.message}</p>}
         <button type="submit">Submit</button>
       </form>
 
@@ -38,8 +53,6 @@ const Home: NextPage = () => {
           <p>{post.body}</p>
         </div>
       ))}
-
-      <pre>Errors: {JSON.stringify(formState, null, 2)}</pre>
     </div>
   );
 };


### PR DESCRIPTION
Hello there.

Creating a PR fixing the hook's options on the README.md file.

I've also changed the way you show errors on the example app because the `JSON.stringify(formState)` doesn't get updated when an error occurs.

I've also added the invalidate onSuccess on the example app because I don't like to wait until tanstack-query re-fetch the content on its own.

Hope this helps. Thanks!